### PR TITLE
Change the example code to use standard node syntax for requiring sign-addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Here is how to retrieve a signed version of an
 [XPI file](https://developer.mozilla.org/en-US/docs/Mozilla/XPI):
 
 ````javascript
-import signAddon from 'sign-addon';
+var signAddon = require('sign-addon').default;
 
 signAddon(
   {


### PR DESCRIPTION
Switch the import to require as that what node/javascript uses.