### PR TITLE
fix(): Added missing source-map-support dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "jsonwebtoken": "5.7.0",
     "mz": "2.4.0",
     "request": "2.70.0",
+    "source-map-support": "0.4.0",
     "stream-to-promise": "1.1.0",
     "when": "3.7.7"
   },


### PR DESCRIPTION
The webpack banner triggers an import of this on the first line of the distribution.