### PR TITLE
Try to run tests with the default npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 node_js:
 - '0.12'
 - '4'
-before_install:
-- npm install -g npm
 script: npm test
 notifications:
   irc:


### PR DESCRIPTION
I'd like to cover installation with the default npm
since it seems to have weird quirks. Not sure if this
will reproduce the 'any-promise' installation failure on
node 0.12 + npm 2.11.3 or not but maybe.