### PR TITLE
fix: Fixed timeouts in case of slow XPI uploads to the signing server

### DIFF
--- a/src/amo-client.js
+++ b/src/amo-client.js
@@ -2,7 +2,7 @@ import deepcopy from "deepcopy";
 import {default as defaultFs} from "fs";
 import url from "url";
 import path from "path";
-import jwt from "jsonwebtoken";
+import defaultJwt from "jsonwebtoken";
 import {default as defaultRequest} from "request";
 import when from "when";
 import nodefn from "when/node";
@@ -17,6 +17,9 @@ const defaultClearInterval = clearInterval;
  *   - `apiKey`: API key string from the Developer Hub.
  *   - `apiSecret`: API secret string from the Developer Hub.
  *   - `apiUrlPrefix`: API URL prefix, including any leading paths.
+ *   - `apiJwtExpiresIn`: Number of seconds until the JWT token for the API
+ *     request expires. This must match the expiration time that the API
+ *     server accepts.
  *   - `signedStatusCheckInterval`: A period in millesconds between
  *     checks when waiting on add-on signing.
  *   - `signedStatusCheckTimeout`: A length in millesconds to give up
@@ -33,6 +36,10 @@ export class Client {
   constructor({apiKey,
                apiSecret,
                apiUrlPrefix,
+               // TODO: put this back to something sane after we
+               // address the file upload issue on AMO:
+               // https://github.com/mozilla/addons-server/issues/3688
+               apiJwtExpiresIn=60 * 5,  // 5 minutes
                debugLogging=false,
                signedStatusCheckInterval=1000,
                signedStatusCheckTimeout=120000,  // 2 minutes.
@@ -46,6 +53,7 @@ export class Client {
     this.apiKey = apiKey;
     this.apiSecret = apiSecret;
     this.apiUrlPrefix = apiUrlPrefix;  // default set in CLI options.
+    this.apiJwtExpiresIn = apiJwtExpiresIn;
     this.signedStatusCheckInterval = signedStatusCheckInterval;
     this.signedStatusCheckTimeout = signedStatusCheckTimeout;
     this.debugLogging = debugLogging;
@@ -406,7 +414,7 @@ export class Client {
    * @return {Object} new requestConf object suitable
    *                  for `request(conf)`, `request.get(conf)`, etc.
    */
-  configureRequest(requestConf) {
+  configureRequest(requestConf, {jwt=defaultJwt}={}) {
     requestConf = {...this.requestConfig, ...requestConf};
     if (!requestConf.url) {
       throw new Error("request URL was not specified");
@@ -418,7 +426,7 @@ export class Client {
 
     var authToken = jwt.sign({iss: this.apiKey}, this.apiSecret, {
       algorithm: "HS256",
-      expiresIn: 60,
+      expiresIn: this.apiJwtExpiresIn,
     });
 
     requestConf.headers = {

--- a/src/amo-client.js
+++ b/src/amo-client.js
@@ -429,6 +429,10 @@ export class Client {
       expiresIn: this.apiJwtExpiresIn,
     });
 
+    // Make sure the request won't time out before the JWT expires.
+    // This may be useful for slow file uploads.
+    requestConf.timeout = (this.apiJwtExpiresIn * 1000) + 500;
+
     requestConf.headers = {
       Authorization: "JWT " + authToken,
       Accept: "application/json",

--- a/src/index.js
+++ b/src/index.js
@@ -20,18 +20,21 @@ export default function signAddon(
     apiSecret,
     // Optional arguments:
     apiUrlPrefix="https://addons.mozilla.org/api/v3",
+    // Number of seconds until the JWT token for the API request expires.
+    // This must match the expiration time that the API server accepts.
+    apiJwtExpiresIn,
     verbose=false,
     // Number of milleseconds to wait before giving up on a
     // response from Mozilla's web service.
-    timeout=undefined,
+    timeout,
     // Absolute directory to save downloaded files in.
-    downloadDir=undefined,
+    downloadDir,
     // Optional proxy to use for all API requests,
     // such as "http://yourproxy:6000"
-    apiProxy=undefined,
+    apiProxy,
     // Optional object to pass into request() for additional configuration.
     // Not all properties are guaranteed to be applied.
-    apiRequestConfig=undefined,
+    apiRequestConfig,
     AMOClient=DefaultAMOClient,
   }) {
 
@@ -72,6 +75,7 @@ export default function signAddon(
         apiKey,
         apiSecret,
         apiUrlPrefix,
+        apiJwtExpiresIn,
         downloadDir,
         debugLogging: verbose,
         signedStatusCheckTimeout: timeout,

--- a/tests/test.amo-client.js
+++ b/tests/test.amo-client.js
@@ -712,6 +712,39 @@ describe("amoClient.Client", function() {
       });
     });
 
+    it("lets you configure the jwt expiration", function() {
+      const expiresIn = 60 * 15; // 15 minutes
+      const cli = this.newClient({
+        apiJwtExpiresIn: expiresIn,
+      });
+
+      const fakeJwt = {
+        sign: sinon.spy(() => "<JWT token>"),
+      };
+      cli.configureRequest({url: "/somewhere"}, {
+        jwt: fakeJwt,
+      });
+
+      expect(fakeJwt.sign.called).to.be.equal(true);
+      // Make sure the JWT expiration is customizable.
+      expect(fakeJwt.sign.args[0][2].expiresIn).to.be.equal(expiresIn);
+    });
+
+    it("configures a default jwt expiration", function() {
+      const defaultExpiry = 60 * 5; // 5 minutes
+      const cli = this.newClient();
+
+      const fakeJwt = {
+        sign: sinon.spy(() => "<JWT token>"),
+      };
+      cli.configureRequest({url: "/somewhere"}, {
+        jwt: fakeJwt,
+      });
+
+      expect(fakeJwt.sign.called).to.be.equal(true);
+      expect(fakeJwt.sign.args[0][2].expiresIn).to.be.equal(defaultExpiry);
+    });
+
     it("lets you configure a request directly", function() {
       var conf = this.client.configureRequest({url: "/path"});
       expect(conf).to.have.keys(["headers", "url"]);

--- a/tests/test.amo-client.js
+++ b/tests/test.amo-client.js
@@ -747,7 +747,7 @@ describe("amoClient.Client", function() {
 
     it("lets you configure a request directly", function() {
       var conf = this.client.configureRequest({url: "/path"});
-      expect(conf).to.have.keys(["headers", "url"]);
+      expect(conf).to.have.keys(["headers", "timeout", "url"]);
       expect(conf.headers).to.have.keys(["Accept", "Authorization"]);
     });
 
@@ -794,6 +794,20 @@ describe("amoClient.Client", function() {
 
       });
       return when.all(requests);
+    });
+
+    it("configures a request timeout based on JWT expiration", function() {
+      // Set a custom JWT expiration:
+      const expiresIn = 60 * 15; // 15 minutes
+      const cli = this.newClient({
+        apiJwtExpiresIn: expiresIn,
+      });
+
+      const config = cli.configureRequest({url: "/somewhere"});
+
+      // Make sure the request is configured to timeout after the
+      // JWT token times out.
+      expect(config.timeout).to.be.above(expiresIn * 1000);
     });
 
     it("requires a URL", function() {

--- a/tests/test.sign.js
+++ b/tests/test.sign.js
@@ -97,6 +97,18 @@ describe("sign", function() {
     });
   });
 
+  it("passes JWT expiration to the signing client", () => {
+    const expiresIn = 60 * 15; // 15 minutes
+    return runSignCmd({
+      cmdOptions: {
+        apiJwtExpiresIn: expiresIn,
+      },
+    }).then(() => {
+      expect(fakeClientContructor.firstCall.args[0].apiJwtExpiresIn)
+        .to.be.equal(expiresIn);
+    });
+  });
+
   it("throws an error for XPI file errors", () => {
     return runSignCmd({
       throwError: false,


### PR DESCRIPTION
The maximum allowed expiration time for JWT authentication has been increased in https://github.com/mozilla/addons-server/pull/3686 to address a problem where slow file uploads delay the validation of the expiration. This bumps the default expiration in the client and also lets the caller configure the value (if needed).