### PR TITLE
chore: Add keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,12 @@
   "bugs": {
     "url": "https://github.com/mozilla/sign-addon/issues"
   },
-  "homepage": "https://github.com/mozilla/sign-addon#readme"
+  "homepage": "https://github.com/mozilla/sign-addon#readme",
+  "keywords": [
+    "AddOn",
+    "Add-on",
+    "sign",
+    "firefox",
+    "WebService"
+  ]
 }


### PR DESCRIPTION
I think I fix the bug that make npm fail, and I add keyword "Add-on" into package.json file as well.