### PR TITLE
chore(package): update request to version 2.79.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "es6-promisify": "5.0.0",
     "jsonwebtoken": "7.1.9",
     "mz": "2.5.0",
-    "request": "2.78.0",
+    "request": "2.79.0",
     "source-map-support": "0.4.6",
     "stream-to-promise": "2.2.0",
     "when": "3.7.7"


### PR DESCRIPTION
This avoids the following deprecation warning upon `npm install`:

    npm WARN deprecated node-uuid@1.4.7: use uuid module instead

`request` switched from `node-uuid` to `uuid` in version 2.79.0:
https://github.com/request/request/commit/263e16ec89edb8041657edb9280d9b0039146845