### PR TITLE
feat: Added optional `channel` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ signAddon(
     // WebExtensions do not require an ID.
     // See the notes below about dealing with IDs.
     id: 'your-addon-id@somewhere',
+    // The release channel (listed or unlisted).
+    // Ignored for new add-ons, which are always unlisted.
+    // Default: most recently used channel.
+    channel: undefined,
     // Save downloaded files to this directory.
     // Default: current working directory.
     downloadDir: undefined,

--- a/src/amo-client.js
+++ b/src/amo-client.js
@@ -77,12 +77,13 @@ export class Client {
    *   - `xpiPath` Path to xpi file.
    *   - `guid` Optional add-on GUID, aka the ID in install.rdf.
    *   - `version` add-on version string.
+   *   - `channel` release channel (listed, unlisted).
    * @return {Promise} signingResult with keys:
    *   - success: boolean
    *   - downloadedFiles: Array of file objects
    *   - id: string identifier for the signed add-on
    */
-  sign({guid, version, xpiPath}) {
+  sign({guid, version, channel, xpiPath}) {
 
     const formData = {
       upload: this._fs.createReadStream(xpiPath),
@@ -93,11 +94,20 @@ export class Client {
       // PUT to a specific URL for this add-on + version.
       addonUrl += encodeURIComponent(guid) +
         "/versions/" + encodeURIComponent(version) + "/";
+      if (channel) {
+        formData.channel = channel;
+      }
     } else {
       // POST to a generic URL to create a new add-on.
       this.debug("Signing add-on without an ID");
       method = "post";
       formData.version = version;
+      if (channel) {
+        this.logger.warn(
+          "Specifying a channel for a new add-on is unsupported. " +
+          "New add-ons are always in the unlisted channel."
+        );
+      }
     }
 
     const doRequest = this[method].bind(this);

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,10 @@ export default function signAddon(
     // This must match the expiration time that the API server accepts.
     apiJwtExpiresIn,
     verbose=false,
+    // The release channel (listed or unlisted).
+    // Ignored for new add-ons, which are always unlisted.
+    // Defaults to most recently used channel.
+    channel,
     // Number of milleseconds to wait before giving up on a
     // response from Mozilla's web service.
     timeout,
@@ -87,6 +91,7 @@ export default function signAddon(
         xpiPath: xpiPath,
         guid: id,
         version: version,
+        channel: channel,
       });
 
     });

--- a/tests/test.sign.js
+++ b/tests/test.sign.js
@@ -97,6 +97,16 @@ describe("sign", function() {
     });
   });
 
+  it("passes release channel to the signer", () => {
+    const channel = "listed";
+    return runSignCmd({
+      cmdOptions: {channel},
+    }).then(function() {
+      expect(signingCall.called).to.be.equal(true);
+      expect(signingCall.firstCall.args[0].channel).to.be.equal(channel);
+    });
+  });
+
   it("passes JWT expiration to the signing client", () => {
     const expiresIn = 60 * 15; // 15 minutes
     return runSignCmd({


### PR DESCRIPTION
Fixes #248

I'm not sure where I should add unit tests if any, would appreciate pointers and I can update this PR. I have tested the changes using my addon: I can specify unlisted channel when the previously used channel was listed and the result is unlisted ready for self-hosting.