### PR TITLE
chore: update conventional-changelog-cli to version 1.3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-preset-es2015": "6.18.0",
     "babel-preset-stage-2": "6.18.0",
     "chai": "3.5.0",
-    "conventional-changelog-cli": "1.2.0",
+    "conventional-changelog-cli": "1.3.13",
     "conventional-changelog-lint": "1.1.0",
     "eslint": "3.9.1",
     "grunt": "1.0.1",


### PR DESCRIPTION
This patch release was a precaution against a previously released malicious version https://github.com/conventional-changelog/conventional-changelog/issues/282#issuecomment-365367804