### PR TITLE
chore: Update dependencies using vulnerable hoek

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "deepcopy": "0.6.3",
     "es6-error": "4.0.0",
     "es6-promisify": "5.0.0",
-    "jsonwebtoken": "7.1.9",
+    "jsonwebtoken": "8.2.1",
     "mz": "2.5.0",
-    "request": "2.79.0",
+    "request": "2.85.0",
     "source-map-support": "0.4.6",
     "stream-to-promise": "2.2.0",
     "when": "3.7.7"


### PR DESCRIPTION
There is a vulnerability in old versions of `hoek` and updating these 2 dependencies should lead to a version of `hoek` that is no longer affected. More information:
- https://nodesecurity.io/advisories/566
- https://hackerone.com/reports/310439

I was informed of this issue today by GitHub (and previously on several occasions by Snyk) since I depend on this package, so I expect I'm not alone in noticing this.

The test suite passes locally using bleeding-edge node/npm. I've checked usages of `jsonwebtoken` in the code and didn't spot anything [affected by the major version bump](https://github.com/auth0/node-jsonwebtoken/wiki/Migration-Notes:-v7-to-v8), its dependency tree no longer features `hoek` at all and should be significantly lighter.

The Travis build on node 0.12 might fail due to lack of ES6 features used by the newer version of `hawk` in `request`, but this should be expected since `request` dropped support for node 0.12 with v2.77 (see request/request#2442)! If supporting that ancient version that reached EOL at the end of 2016 is still desired then migrating away from `request` to something like [`needle`](https://www.npmjs.com/package/needle) might be necessary.

Edit: seems the Travis node 4 build also failed, this time because the latest version of `npm` itself uses an ES6 feature not supported on node 4...

Edit 2: having checked [the Snyk report](https://snyk.io/test/npm/sign-addon) more thoroughly, there are additional vulnerable dependencies that would be resolved or partially resolved by this PR:
- [`tunnel-agent` < 0.6.0](https://snyk.io/vuln/npm:tunnel-agent:20170305)
- [`ms` < 2.0.0](https://snyk.io/vuln/npm:ms:20170412) (still present via devDependencies `grunt-contrib-watch@1.0.0` and `mocha@3.1.2`)