### PR TITLE
fix: Update direct npm production deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,24 @@
 language: node_js
 sudo: false
 node_js:
-- '0.12'
-- '4'
+- '6'
+- '8'
+
 before_install:
 # Create a master branch for conventional-changelog-lint
 - git remote set-branches origin master && git fetch
 - git checkout master
 # Check out the commit that TravisCI started on:
 - git checkout -
-# On 0.12, we want to test with the default version of npm, otherwise
+# On nodejs 6, we want to test with the default version of npm, otherwise
 # upgrade to the latest.
-- if [[ ${TRAVIS_NODE_VERSION:0:1} -gt "0" ]]; then
+- if [[ ${TRAVIS_NODE_VERSION:0:1} -gt "6" ]]; then
     npm install -g npm;
   fi
 script:
 - npm test
 # Run changelog-lint but only on newer versions of Node (because of syntax errors)
-- if [[ ${TRAVIS_NODE_VERSION:0:1} -ge "4" ]]; then
+- if [[ ${TRAVIS_NODE_VERSION:0:1} -ge "8" ]]; then
     npm run changelog-lint;
   fi
 notifications:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "deepcopy": "0.6.3",
     "es6-error": "4.0.0",
     "es6-promisify": "5.0.0",
-    "jsonwebtoken": "7.1.9",
+    "jsonwebtoken": "8.2.1",
     "mz": "2.5.0",
     "request": "2.79.0",
     "source-map-support": "0.4.6",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "es6-promisify": "5.0.0",
     "jsonwebtoken": "8.2.1",
     "mz": "2.5.0",
-    "request": "2.79.0",
+    "request": "2.87.0",
     "source-map-support": "0.4.6",
     "stream-to-promise": "2.2.0",
     "when": "3.7.7"


### PR DESCRIPTION
This PR updates jsonwebtoken and request to their last versions, which is needed to solve the following security issue with their dependencies, e.g.:

- request@2.87.0, which updates to a non vulnerable version:
  - hoek (https://nodesecurity.io/advisories/566)
  - tunnel-agent (https://nodesecurity.io/advisories/598)

- jsonwebtoken@8.2.1, which updates to a non vulnerable version:
  - hoek (https://nodesecurity.io/advisories/566)

The travis config is also being updated to run the tests on nodejs 6 and nodejs 8. 