### PR TITLE
drop support for node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-- '6'
-- '8'
+- 8
+- 10
 
 before_install:
 # Create a master branch for conventional-changelog-lint
@@ -10,11 +10,7 @@ before_install:
 - git checkout master
 # Check out the commit that TravisCI started on:
 - git checkout -
-# On nodejs 6, we want to test with the default version of npm, otherwise
-# upgrade to the latest.
-- if [[ ${TRAVIS_NODE_VERSION:0:1} -gt "6" ]]; then
-    npm install -g npm;
-  fi
+- npm install -g npm;
 script:
 - npm test
 # Run changelog-lint but only on newer versions of Node (because of syntax errors)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ secret, from the
 [AMO Developer Hub](https://addons.mozilla.org/en-US/developers/addon/api/key/).
 
 Currently, this is intended for use in [NodeJS](https://nodejs.org/) only
-and should work in 0.12 or higher.
+and should work in version 8 or higher.
 
 ## Command line use
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sign-addon",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "description": "Signs a Firefox add-on using Mozilla's web service",
   "main": "dist/sign-addon.js",
   "scripts": {

--- a/src/amo-client.js
+++ b/src/amo-client.js
@@ -673,9 +673,10 @@ export function formatResponse(response, options) {
     ...options,
   };
   var prettyResponse = response;
+  var stringify = options._stringifyToJson || JSON.stringify;
   if (typeof prettyResponse === "object") {
     try {
-      prettyResponse = JSON.stringify(prettyResponse);
+      prettyResponse = stringify(prettyResponse);
     } catch (e) {
       //
     }

--- a/tests/test.amo-client.js
+++ b/tests/test.amo-client.js
@@ -969,7 +969,11 @@ describe("amoClient.formatResponse", function() {
   });
 
   it("ignores broken JSON objects", function() {
-    var res = amoClient.formatResponse({unserializable: process});  // any complex object
+    var stub = sinon.stub().throws();
+    var res = amoClient.formatResponse(
+      {unserializable: process}, // any complex object
+      {_stringifyToJson: stub}
+    );
     expect(res).to.be.equal("[object Object]");
   });
 


### PR DESCRIPTION
Fixes #269

I updated README, node versions for travis and version in package.json

The test failing in v10 is because `JSON.stringify` isn't failing to convert `process` (and assume other  complex object too).
I'm tempt to remove the test, but what do you think?

https://github.com/mozilla/sign-addon/blob/3473ccdb8cf5f9de8554cd86186c49af21357d62/tests/test.amo-client.js#L971-L974

https://github.com/mozilla/sign-addon/blob/3473ccdb8cf5f9de8554cd86186c49af21357d62/src/amo-client.js#L670-L688