### PR TITLE
feat: Provide more detailed errors in the response object

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ signAddon({
       console.log(result.id);
     } else {
       console.error('Your add-on could not be signed!');
-      console.error('Check the console for details.');
+      console.error('Error code: ' + result.errorCode);
+      console.error('Details: ' + result.errorDetails);
     }
     console.log(result.success ? 'SUCCESS' : 'FAIL');
   })

--- a/src/amo-client.js
+++ b/src/amo-client.js
@@ -72,9 +72,9 @@ import PseudoProgress from './PseudoProgress';
  * @typedef {{
  *   success: boolean,
  *   id: string | null,
- *   downloadedFiles: ?string[],
- *   errorCode: ?SignErrorCode,
- *   errorDetails: ?string
+ *   downloadedFiles: string[] | null,
+ *   errorCode: SignErrorCode | null,
+ *   errorDetails: string | null
  * }} SignResult
  */
 
@@ -406,6 +406,7 @@ export class Client {
               );
 
               _clearTimeout(abortTimeout);
+
               resolve({
                 success: false,
                 id: null,

--- a/src/amo-client.js
+++ b/src/amo-client.js
@@ -71,7 +71,7 @@ import PseudoProgress from './PseudoProgress';
 /**
  * @typedef {{
  *   success: boolean,
- *   id: ?string,
+ *   id: string | null,
  *   downloadedFiles: ?string[],
  *   errorCode: ?SignErrorCode,
  *   errorDetails: ?string
@@ -364,8 +364,7 @@ export class Client {
               // TODO: show some validation warnings if there are any. We should
               // show things like "missing update URL in manifest"
               const result = await this.downloadSignedFiles(status.files);
-              result.id = status.guid;
-              resolve(result);
+              resolve({ ...result, id: status.guid });
             }
           } else {
             // The add-on has not been fully processed yet.
@@ -649,7 +648,7 @@ export class Client {
   }
 
   /**
-   * Confgures a request with defaults such as authentication headers.
+   * Configures a request with defaults such as authentication headers.
    *
    * @param {RequestConfig} config - as accepted by the `request` module
    * @param {{ jwt?: typeof defaultJwt}} options

--- a/tests/amo-client.spec.js
+++ b/tests/amo-client.spec.js
@@ -239,6 +239,8 @@ describe(__filename, () => {
 
         expect(waitForSignedAddonStub).not.toHaveBeenCalled();
         expect(result.success).toEqual(false);
+        expect(result.errorCode).toEqual('SERVER_FAILURE');
+        expect(result.errorDetails).toEqual('version already exists');
       });
 
       it('handles incorrect status code for error responses', function() {
@@ -253,6 +255,8 @@ describe(__filename, () => {
 
         return sign().then((result) => {
           expect(result.success).toEqual(false);
+          expect(result.errorCode).toEqual('SERVER_FAILURE');
+          expect(result.errorDetails).toEqual('some server error');
         });
       });
 
@@ -376,7 +380,11 @@ describe(__filename, () => {
         client._request = new MockRequest({
           responseQueue: [
             createValidationResponse({ valid: false, processed: false }),
-            createValidationResponse({ valid: false, processed: true }),
+            createValidationResponse({
+              valid: false,
+              processed: true,
+              validation_url: 'http://amo/validation',
+            }),
           ],
         });
 
@@ -384,6 +392,8 @@ describe(__filename, () => {
           // Expect exactly two GETs before resolution.
           expect(client._request.calls.length).toEqual(2);
           expect(result.success).toEqual(false);
+          expect(result.errorCode).toEqual('VALIDATION_FAILED');
+          expect(result.errorDetails).toEqual('http://amo/validation');
         });
       });
 
@@ -416,6 +426,7 @@ describe(__filename, () => {
 
         return waitForSignedAddon().then(function(result) {
           expect(result.success).toEqual(false);
+          expect(result.errorCode).toEqual('ADDON_NOT_AUTO_SIGNED');
         });
       });
 


### PR DESCRIPTION
When using sign-addon programatically, having more details on the response object would be nice.