### PR TITLE
feat: drop node 8 support, start adding async/await

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,7 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": [
+    ["@babel/preset-env", {
+      "targets": { "node": "current" }
+    }]
+  ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-- 8
 - 10
 - 12
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,6 +1135,12 @@
       "integrity": "sha512-7qvf9F9tMTzo0akeswHPGqgUx/gIaJqrOEET/FCD8CFRkSUHlygQiM5yB6OvjrtdxBVLSyw7COJubsFYs0683g==",
       "dev": true
     },
+    "@types/common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@types/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-htRqZr5qn8EzMelhX/Xmx142z218lLyGaeZ3YR8jlze4TATRU9huKKvuBmAJEW4LCC4pnY1N6JAm6p85fMHjhg==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2569,6 +2575,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
+    },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
     },
     "commondir": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "prettier": "prettier --write '**'",
     "prettier-ci": "prettier --list-different '**' || (echo '\n\nThis failure means you did not run `yarn prettier-dev` before committing\n\n' && exit 1)",
     "prettier-dev": "pretty-quick --branch master",
-    "test": "mocha --require @babel/register --reporter=spec tests/",
+    "test": "mocha --require @babel/register --reporter=spec --exit tests/",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "core-js": "3.3.6",
+    "common-tags": "1.8.0",
     "deepcopy": "2.0.0",
     "es6-error": "4.1.1",
     "es6-promisify": "6.0.2",
@@ -33,6 +34,7 @@
     "@commitlint/cli": "8.2.0",
     "@commitlint/config-conventional": "8.2.0",
     "@types/chai": "4.2.4",
+    "@types/common-tags": "1.8.0",
     "@types/jsonwebtoken": "8.3.5",
     "@types/mocha": "5.2.7",
     "@types/mz": "0.0.32",

--- a/src/PseudoProgress.js
+++ b/src/PseudoProgress.js
@@ -1,0 +1,138 @@
+/**
+ * @typedef {{
+ *   isTTY: boolean;
+ *   columns: number;
+ *   write: (buffer: string) => boolean;
+ * }} Stdout
+ */
+
+/**
+ * A pseudo progress indicator.
+ *
+ * This is just a silly shell animation that was meant to simulate how lots of
+ * tests would be run on an add-on file. It sort of looks like a torrent file
+ * randomly getting filled in.
+ */
+class PseudoProgress {
+  /**
+   * @typedef {object} PseudoProgressParams
+   * @property {string=} preamble
+   * @property {typeof clearInterval=} _clearInterval
+   * @property {Stdout=} stdout
+   * @property {typeof setInterval=} _setInterval
+   *
+   * @param {PseudoProgressParams} params
+   */
+  constructor({
+    _clearInterval = clearInterval,
+    _setInterval = setInterval,
+    preamble = '',
+    stdout = process.stdout,
+  } = {}) {
+    /** @type {string[]} */
+    this.bucket = [];
+    this.interval = null;
+    this.motionCounter = 1;
+
+    this.preamble = preamble;
+    this.preamble += ' [';
+    this.addendum = ']';
+    this.setInterval = _setInterval;
+    this.clearInterval = _clearInterval;
+    this.stdout = stdout;
+
+    let shellWidth = 80;
+    if (this.stdout.isTTY) {
+      shellWidth = Number(this.stdout.columns);
+    }
+
+    /** @type {number[]} */
+    this.emptyBucketPointers = [];
+    const bucketSize = shellWidth - this.preamble.length - this.addendum.length;
+    for (let i = 0; i < bucketSize; i++) {
+      this.bucket.push(' ');
+      this.emptyBucketPointers.push(i);
+    }
+  }
+
+  /**
+   * @typedef {object} AnimateConfig
+   * @property {number} speed
+   *
+   * @param {AnimateConfig=} animateConfig
+   */
+  animate(animateConfig) {
+    const conf = {
+      speed: 100,
+      ...animateConfig,
+    };
+    let bucketIsFull = false;
+    this.interval = this.setInterval(() => {
+      if (bucketIsFull) {
+        this.moveBucket();
+      } else {
+        bucketIsFull = this.randomlyFillBucket();
+      }
+    }, conf.speed);
+  }
+
+  finish() {
+    if (this.interval) {
+      this.clearInterval(this.interval);
+    }
+
+    this.fillBucket();
+    // The bucket has already filled to the terminal width at this point
+    // but for copy/paste purposes, add a new line:
+    this.stdout.write('\n');
+  }
+
+  randomlyFillBucket() {
+    // randomly fill a bucket (the width of the shell) with dots.
+    const randomIndex = Math.floor(
+      Math.random() * this.emptyBucketPointers.length,
+    );
+    this.bucket[this.emptyBucketPointers[randomIndex]] = '.';
+
+    this.showBucket();
+
+    let isFull = true;
+    /** @type {number[]} */
+    const newPointers = [];
+    this.emptyBucketPointers.forEach((pointer) => {
+      if (this.bucket[pointer] === ' ') {
+        isFull = false;
+        newPointers.push(pointer);
+      }
+    });
+    this.emptyBucketPointers = newPointers;
+
+    return isFull;
+  }
+
+  fillBucket() {
+    // fill the whole bucket with dots to indicate completion.
+    this.bucket = this.bucket.map(function() {
+      return '.';
+    });
+    this.showBucket();
+  }
+
+  moveBucket() {
+    // animate dots moving in a forward motion.
+    for (let i = 0; i < this.bucket.length; i++) {
+      this.bucket[i] = (i - this.motionCounter) % 3 ? ' ' : '.';
+    }
+    this.showBucket();
+
+    this.motionCounter++;
+  }
+
+  showBucket() {
+    this.stdout.write(
+      `\r${this.preamble}${this.bucket.join('')}${this.addendum}`,
+    );
+  }
+}
+
+export default PseudoProgress;

--- a/tests/PseudoProgress.spec.js
+++ b/tests/PseudoProgress.spec.js
@@ -1,0 +1,50 @@
+import sinon from 'sinon';
+import { beforeEach, describe, it } from 'mocha';
+import { expect } from 'chai';
+
+import PseudoProgress from '../src/PseudoProgress';
+
+describe(__filename, () => {
+  describe('PseudoProgress', () => {
+    /** @type {sinon.SinonSpy} */
+    let _clearInterval;
+    /** @type {sinon.SinonSpy} */
+    let _setInterval;
+    /** @type {PseudoProgress} */
+    let progress;
+
+    const createFakeStdout = () => {
+      return {
+        columns: 80,
+        isTTY: true,
+        // eslint-disable-next-line no-unused-vars
+        write(buffer = '') {
+          return true;
+        },
+      };
+    };
+
+    beforeEach(() => {
+      _setInterval = sinon.spy(() => 'interval-id');
+      _clearInterval = sinon.spy(() => {});
+
+      progress = new PseudoProgress({
+        _clearInterval,
+        _setInterval,
+        stdout: createFakeStdout(),
+      });
+    });
+
+    it('should set an interval', function() {
+      progress.animate();
+      expect(_setInterval.called).to.be.equal(true);
+    });
+
+    it('should clear an interval', function() {
+      progress.animate();
+      expect(_setInterval.called).to.be.equal(true);
+      progress.finish();
+      expect(_clearInterval.firstCall.args[0]).to.be.equal('interval-id');
+    });
+  });
+});


### PR DESCRIPTION
This patch has been extracted while working on https://github.com/mozilla/sign-addon/pull/323. That will likely reduce the diff of this other patch and hopefully make it easier to follow.

Likely fixes https://github.com/mozilla/sign-addon/issues/324

Changes:

- drop node 8 support (may not be needed but...)
  - `web-ext` removed Node 8 support in https://github.com/mozilla/web-ext/issues/1556
- move `PseudoProgress` class to its own file
- switch to async/await when easily possible