### PR TITLE
Move noEmit into tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prettier-ci": "prettier --list-different '**' || (echo '\n\nThis failure means you did not run `yarn prettier-dev` before committing\n\n' && exit 1)",
     "prettier-dev": "pretty-quick --branch master",
     "test": "mocha --require @babel/register --reporter=spec --exit tests/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc"
   },
   "dependencies": {
     "core-js": "3.3.6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "checkJs": true,
     "esModuleInterop": true,
     "module": "commonjs",
+    "noEmit": true,
     "moduleResolution": "node",
     "strict": true,
     "target": "es2015",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,8 @@
     "checkJs": true,
     "esModuleInterop": true,
     "module": "commonjs",
-    "noEmit": true,
     "moduleResolution": "node",
+    "noEmit": true,
     "strict": true,
     "target": "es2015",
     "typeRoots" : ["./node_modules/@types", "./src/@types"]


### PR DESCRIPTION
The `noEmit` value should be defined in tsconfig so that IDEs such as VSCode know what to do.

As you might have guessed, I've been trying to go all in on VSCode lately 😬 