### PR TITLE
fix: Avoid mz npm deps to be directly required from the webpack…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import fs from 'mz/fs';
+import { fs } from 'mz';
 
 import { Client as DefaultAMOClient } from './amo-client';
 


### PR DESCRIPTION
By using `import fs from 'mz/fs'` instead of `import {fs} from 'mz'`,
the resulting webpack bundle contains require calls for modules that
are not direct dependencies of the sign-addon package, but dependencies
of the mz package.

This small detail may trigger issues like:
- https://github.com/mozilla/web-ext/issues/1629
now covered against regressions by a "smoke test" running
on the web-ext CI jobs (the smoke test triggers this kind of unexpected
issue by running all the functional tests on an environment created
using `npm install --production --legacy-bundling`, which generates
a non deduplicated node_modules directory tree).

This small change should prevent the web-ext "smoke test" from failing on
https://github.com/mozilla/web-ext/pull/1768
without adding the mz dependency as direct dependency of the web-ext package.

----

Before this change:
```
npx js-beautify dist/sign-addon.js | grep require\(\"
npx: installed 29 in 1.819s
require("source-map-support").install(), module.exports = function(e) {
    e.exports = require("common-tags")
    e.exports = require("fs")
    e.exports = require("path")
    e.exports = require("url")
    e.exports = require("deepcopy")
    e.exports = require("jsonwebtoken")
    e.exports = require("request")
    e.exports = require("any-promise")
    e.exports = require("graceful-fs")
    e.exports = require("thenify-all")
```

and then after it:

```
require("source-map-support").install(), module.exports = function(e) {
    e.exports = require("common-tags")
    e.exports = require("fs")
    e.exports = require("path")
    e.exports = require("mz")
    e.exports = require("url")
    e.exports = require("deepcopy")
    e.exports = require("jsonwebtoken")
    e.exports = require("request")
```