### PR TITLE
fix: Added coverage dir to .npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 npm-debug.log
 node_modules
 dist/*
+coverage

--- a/.npmignore
+++ b/.npmignore
@@ -1,11 +1,2 @@
-# OSX
-.DS_Store
-
-# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
-.grunt
-.cache
-
-# Development artifacts.
-npm-debug.log
-dist/tests.js*
-tests
+# The files to be included in the npm package are listed in the package.json file,
+# in the `files` property (See https://docs.npmjs.com/files/package.json#files).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "2.0.3",
   "description": "Signs a Firefox add-on using Mozilla's web service",
   "main": "dist/sign-addon.js",
+  "files": [
+    "CODE_OF_CONDUCT.md",
+    "dist/sign-addon.*",
+    "src/**"
+  ],
   "scripts": {
     "build": "rimraf dist/ && webpack",
     "changelog": "conventional-changelog -p angular -u",


### PR DESCRIPTION
While looking to the diff on the last released version, I noticed that we are currently including in the sign-addon package released on npm the generated coverage files.

(To be fair there are also other files that we may exclude from the npm package, see https://unpkg.com/browse/sign-addon@2.0.3/)