### PR TITLE
fix: Use webpack-node-externals to avoid bundling node_modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10368,6 +10368,12 @@
         }
       }
     },
+    "webpack-node-externals": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
+      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==",
+      "dev": true
+    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "rimraf": "3.0.0",
     "typescript": "3.7.4",
     "webpack": "4.41.5",
-    "webpack-cli": "3.3.10"
+    "webpack-cli": "3.3.10",
+    "webpack-node-externals": "1.7.2"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,19 +1,7 @@
 const path = require('path');
-const fs = require('fs');
 
 const webpack = require('webpack');
-
-const nodeModules = {};
-
-// This is to filter out node_modules as we don't want them
-// to be made part of any bundles.
-fs.readdirSync('node_modules')
-  .filter(function(x) {
-    return ['.bin'].indexOf(x) === -1;
-  })
-  .forEach(function(mod) {
-    nodeModules[mod] = `commonjs ${mod}`;
-  });
+const nodeExternals = require('webpack-node-externals');
 
 module.exports = {
   entry: './src/index.js',
@@ -39,7 +27,11 @@ module.exports = {
       },
     ],
   },
-  externals: nodeModules,
+  externals: [
+    nodeExternals({
+      modulesFromFile: true,
+    }),
+  ],
   plugins: [
     // for when: https://github.com/webpack/webpack/issues/353
     new webpack.IgnorePlugin({


### PR DESCRIPTION
This would have been the proper fix to #383 .

For more details, see https://github.com/mozilla/web-ext/pull/1814 and the linked PRs.