### PR TITLE
docs: Aligned README example with code timeout default

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ signAddon({
   // Default: current working directory.
   downloadDir: undefined,
   // Number of milliseconds to wait before aborting the request.
-  // Default: 2 minutes.
+  // Default: 15 minutes.
   timeout: undefined,
   // Optional proxy to use for all API requests,
   // such as "http://yourproxy:6000"


### PR DESCRIPTION
The default timeout for signing was updated a while back in commit 47d4cf23d6ae3d5f0961e6c461b28836111fa5c9, but the example in the README wasn't. This change just brings the README example back up to date with what's in the code.