### PR TITLE
feat: Added a source uploading to AMO

### DIFF
--- a/src/amo-client.js
+++ b/src/amo-client.js
@@ -63,6 +63,7 @@ import PseudoProgress from './PseudoProgress';
  * @property {string} version - add-on version string
  * @property {ReleaseChannel=} channel - release channel (listed or unlisted)
  * @property {string} xpiPath - path to xpi file
+ * @property {string=} sourceArchivePath - path to source archive file
  */
 
 /**
@@ -200,10 +201,11 @@ export class Client {
    * @param {SignParams} signParams
    * @returns {Promise<SignResult>}
    */
-  sign({ guid, version, channel, xpiPath }) {
+  sign({ guid, version, channel, xpiPath, sourceArchivePath }) {
     /**
      * @type {{
      *   upload: defaultFs.ReadStream;
+     *   source?: defaultFs.ReadStream;
      *   channel?: string;
      *   version?: string;
      * }}
@@ -232,6 +234,9 @@ export class Client {
             'New add-ons are always in the unlisted channel.',
         );
       }
+    }
+    if (sourceArchivePath) {
+      formData.source = this._fs.createReadStream(sourceArchivePath);
     }
 
     return httpMethod

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import { Client as DefaultAMOClient } from './amo-client';
  * @property {ClientParams['requestConfig']=} apiRequestConfig
  * @property {typeof DefaultAMOClient=} AMOClient
  * @property {ClientParams['disableProgressBar']=} disableProgressBar
+ * @property {string=} sourceArchivePath
  *
  * @param {SignAddonParams} params
  */
@@ -60,6 +61,8 @@ const signAddon = async ({
   apiRequestConfig,
   // Optional boolean passed to the AMO client to disable the progress bar.
   disableProgressBar = false,
+  // Source code .zip, .tar.gz, .tgz, .tar.bz2 archive
+  sourceArchivePath,
   AMOClient = DefaultAMOClient,
 }) => {
   /**
@@ -110,6 +113,7 @@ const signAddon = async ({
 
   return client.sign({
     xpiPath,
+    sourceArchivePath,
     guid: id,
     version,
     channel,

--- a/tests/amo-client.spec.js
+++ b/tests/amo-client.spec.js
@@ -210,6 +210,36 @@ describe(__filename, () => {
         );
       });
 
+      it('lets you sign an add-on with source archive', async () => {
+        const _createFakeFS = () => {
+          return {
+            createReadStream(_path) {
+              return _path === 'test-archive-path'
+                ? 'fake-archive-stream'
+                : 'fake-other-stream';
+            },
+          };
+        };
+        const _client = createClient({
+          fs: _createFakeFS(),
+        });
+        _client.waitForSignedAddon = jest.fn();
+        _client._request = new MockRequest({
+          httpResponse: { statusCode: 200 },
+        });
+        const conf = {
+          guid: 'some-guid',
+          version: 'some-version',
+          xpiPath: 'some-xpi-path',
+          sourceArchivePath: 'test-archive-path',
+        };
+        _client.sign(conf);
+
+        expect(_client._request.calls[0].conf.formData.source).toEqual(
+          'fake-archive-stream',
+        );
+      });
+
       it('lets you sign an add-on without an ID ignoring channel', async () => {
         const conf = {
           guid: null,


### PR DESCRIPTION
https://github.com/mozilla/sign-addon/issues/409 Added source code uploading to AMO on sign method. Building an archive should be done on the caller side (like web-ext).