### PR TITLE
Use Node 16 and 18 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ references:
     working_directory: ~/sign-addon
     docker:
       # This is the NodeJS version we run in production.
-      - image: cimg/node:14.21
+      - image: cimg/node:16.19
 
   defaults-next: &defaults-next
     working_directory: ~/sign-addon
     docker:
       # This is the next NodeJS version we will support.
-      - image: cimg/node:16.19
+      - image: cimg/node:18.12
 
   restore_build_cache: &restore_build_cache
     restore_cache:


### PR DESCRIPTION
Add-ons services already use Node 16 by default (or in production). Let's make it the default in the other repos too.